### PR TITLE
Fix dependency conflict, bump version of GoodData Pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ llama-index==0.10.16
 langchain_openai==0.1.1
 faiss-cpu==1.8.0
 duckdb==0.10.2
-lancedb==0.6.10
-pyarrow==16.0.0
+lancedb==0.6.11
+pyarrow>=15.0.0
 python-dotenv==1.0.0
 tabulate==0.9.0
-gooddata_pandas==1.14.0
+gooddata_pandas==1.18.1
 pyyaml>=5.1
 streamlit==1.31.1
 streamlit-chat==0.1.1


### PR DESCRIPTION
LanceDB depends on PyArrow 15 now, we cannot use v16 yet.